### PR TITLE
fix: use assembly version in Stremio manifest instead of hardcoded value

### DIFF
--- a/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
+++ b/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
@@ -26,6 +27,9 @@ namespace Jellyfin.Plugin.Jellio.Controllers;
 [Produces(MediaTypeNames.Application.Json)]
 public class AddonController : ControllerBase
 {
+    private static readonly string PluginVersion =
+        Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
+
     private readonly IUserManager _userManager;
     private readonly IUserViewManager _userViewManager;
     private readonly IDtoService _dtoService;
@@ -221,7 +225,7 @@ public class AddonController : ControllerBase
         var manifest = new
         {
             id = "com.stremio.jellio",
-            version = "0.0.1",
+            version = PluginVersion,
             name = "Jellio",
             description = descriptionText,
             resources = new object[]

--- a/Jellyfin.Plugin.Jellio/Jellyfin.Plugin.Jellio.csproj
+++ b/Jellyfin.Plugin.Jellio/Jellyfin.Plugin.Jellio.csproj
@@ -8,9 +8,8 @@
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    <Version>1.1.7</Version>
-    <AssemblyVersion>1.1.7.0</AssemblyVersion>
-    <FileVersion>1.1.7.0</FileVersion>
+    <!-- Version is set by jprm from the git tag at release time -->
+    <Version Condition="'$(Version)' == ''">0.0.0-dev</Version>
     <Description>Jellyfin to Stremio bridge - stream your personal media library through Stremio.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
The Stremio addon manifest includes a version field that's displayed in the Stremio addons list. It was hardcoded to `0.0.1`, so every release showed that regardless of the actual plugin version.

Now the manifest reads the version from assembly metadata, which `jprm` already sets from the git tag at release time - so the Stremio addon version stays in sync with the Jellyfin plugin version automatically.