### PR TITLE
fix: switch to HLS streaming to fix seeking and transcoding

### DIFF
--- a/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
+++ b/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
@@ -18,6 +18,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Jellyfin.Plugin.Jellio.Controllers;
@@ -174,7 +175,26 @@ public class AddonController : ControllerBase
 
             return dto.MediaSources.Select(source =>
             {
-                var streamUrl = $"{baseUrl}/videos/{dto.Id}/stream?mediaSourceId={source.Id}&api_key={Uri.EscapeDataString(authToken)}&AudioCodec=aac&TranscodingMaxAudioChannels=2&CopyTimestamps=true";
+                /*
+                 * Jellyfin's HLS endpoint requires the caller to declare which codecs the player supports.
+                 * It compares these against the media file's codecs to decide whether to pass through without re-encoding or transcode.
+                 *
+                 * Stremio's addon protocol has no mechanism for the client to advertise its codec capabilities to addons, so we hardcode them here. The lists below reflect what Stremio's players can decode. This is the same pattern every Jellyfin client follows - e.g. jellyfin-web builds its codec list.
+                 * See: https://github.com/jellyfin/jellyfin-web/blob/285196329/src/scripts/browserDeviceProfile.js#L914-L925
+                 *
+                 * Without these params Jellyfin would fall back to "m3u8" as the audio codec name, producing invalid FFmpeg commands.
+                 * See: https://github.com/jellyfin/jellyfin/issues/12926
+                 */
+                string[] videoCodecs = ["h264", "hevc", "av1"];
+                string[] audioCodecs = ["aac", "mp3", "ac3", "eac3", "flac", "opus"];
+                var query = QueryString.Create(new Dictionary<string, string?>
+                {
+                    ["mediaSourceId"] = source.Id,
+                    ["api_key"] = authToken,
+                    ["videoCodec"] = string.Join(',', videoCodecs),
+                    ["audioCodec"] = string.Join(',', audioCodecs),
+                });
+                var streamUrl = $"{baseUrl}/Videos/{dto.Id}/master.m3u8{query}";
                 LogBuffer.AddLog($"[Stream] Generated stream for {dto.Name} ({dto.Id}): {source.Name} - URL: {streamUrl}", LogLevel.Info);
                 return new StreamDto
                 {
@@ -186,6 +206,7 @@ public class AddonController : ControllerBase
                         Filename = string.IsNullOrEmpty(source.Path) ? null : Path.GetFileName(source.Path),
                         VideoSize = source.Size,
                         VideoHash = OpenSubtitlesHash.ComputeFromPath(source.Path),
+                        NotWebReady = true,
                     },
                 };
             });
@@ -318,7 +339,7 @@ public class AddonController : ControllerBase
         };
         var result = folder.GetItems(query);
         var dtos = _dtoService.GetBaseItemDtos(result.Items, dtoOptions, user);
-    var baseUrl = GetBaseUrl(config.PublicBaseUrl);
+        var baseUrl = GetBaseUrl(config.PublicBaseUrl);
         var metas = dtos.Select(dto => MapToMeta(dto, stremioType, baseUrl));
 
         return Ok(new { metas });

--- a/Jellyfin.Plugin.Jellio/Models/BehaviorHintsDto.cs
+++ b/Jellyfin.Plugin.Jellio/Models/BehaviorHintsDto.cs
@@ -15,4 +15,8 @@ public class BehaviorHintsDto
     [JsonPropertyName("videoSize")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public long? VideoSize { get; set; }
+
+    [JsonPropertyName("notWebReady")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool NotWebReady { get; set; }
 }


### PR DESCRIPTION
## Summary

Switch the stream URL from `/videos/{id}/stream` to `/Videos/{id}/master.m3u8` (Jellyfin's HLS endpoint). This fixes seeking/progress bar issues and enables proper transcoding.

### Why

The old `/stream` endpoint sends one continuous byte stream. When transcoding, Jellyfin doesn't know the total output size upfront, so Stremio can't show duration or seek. HLS splits the video into small segments with a playlist - Stremio knows exactly how long the video is and can jump to any segment.

### How transcoding works now

The HLS URL includes a list of codecs the player supports. Jellyfin compares these against the media file and picks the right path:
- Pass through - codec already supported, just repackage into HLS segments.
- Partial transcode - e.g. video is H.264 but audio is DTS - copy video, only re-encode audio
- Full transcode - exotic codec, re-encode everything

### Changes

- Stream URL switched from `/videos/{id}/stream` to `/Videos/{id}/master.m3u8`
- Declared supported codecs in the HLS URL - required by Jellyfin to avoid [falling back to "m3u8" as the audio codec](https://github.com/jellyfin/jellyfin/issues/12926). Same pattern as [jellyfin-web](https://github.com/jellyfin/jellyfin-web/blob/285196329/src/scripts/browserDeviceProfile.js#L914-L925).
- Added `behaviorHints.notWebReady = true` so Stremio uses its native player for HLS
- Removed `TranscodingMaxAudioChannels=2` - no longer forces stereo downmix, surround audio is now passed through when supported
- Removed `CopyTimestamps=true` - irrelevant for HLS, timestamps are handled per-segment
- URL building now uses `QueryString.Create` instead of manual string interpolation

### Related issues

- Fixes https://github.com/InfiniteAvenger/jellio-plus/issues/2
- Fixes https://github.com/InfiniteAvenger/jellio-plus/issues/3
- Fixes https://github.com/InfiniteAvenger/jellio-plus/issues/5
- Fixes https://github.com/InfiniteAvenger/jellio-plus/issues/6
- Fixes https://github.com/InfiniteAvenger/jellio-plus/issues/7