### PR TITLE
chore: fix lint errors

### DIFF
--- a/jellio-web/src/components/configForm/fields/jellyseerr.tsx
+++ b/jellio-web/src/components/configForm/fields/jellyseerr.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
+import type { ConfigFormType } from '@/components/configForm/formSchema.tsx';
 import { Checkbox } from '@/components/ui/checkbox.tsx';
 import {
   FormControl,
@@ -12,7 +13,7 @@ import {
 import { Input } from '@/components/ui/input.tsx';
 
 interface Props {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<ConfigFormType>;
 }
 
 export const JellyseerrFieldset: FC<Props> = ({ form }) => {

--- a/jellio-web/src/components/configForm/fields/libraries.tsx
+++ b/jellio-web/src/components/configForm/fields/libraries.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
+import type { ConfigFormType } from '@/components/configForm/formSchema.tsx';
 import { Checkbox } from '@/components/ui/checkbox.tsx';
 import {
   FormControl,
@@ -12,7 +13,7 @@ import {
 import type { Library } from '@/types';
 
 interface Props {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<ConfigFormType>;
   serverName: string;
   libraries: Library[];
 }
@@ -44,13 +45,11 @@ export const LibrariesField: FC<Props> = ({ form, serverName, libraries }) => {
                     >
                       <FormControl>
                         <Checkbox
-                          checked={field.value?.some(
-                            (v: Library) => v.key === item.key,
-                          )}
+                          checked={field.value.some((v) => v.key === item.key)}
                           onCheckedChange={(checked) => {
                             return checked
                               ? field.onChange([
-                                  ...(field.value || []),
+                                  ...field.value,
                                   {
                                     key: item.key,
                                     name: item.name,
@@ -58,8 +57,8 @@ export const LibrariesField: FC<Props> = ({ form, serverName, libraries }) => {
                                   },
                                 ])
                               : field.onChange(
-                                  field.value?.filter(
-                                    (value: any) => value.key !== item.key,
+                                  field.value.filter(
+                                    (value) => value.key !== item.key,
                                   ),
                                 );
                           }}

--- a/jellio-web/src/components/configForm/fields/serverName.tsx
+++ b/jellio-web/src/components/configForm/fields/serverName.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
+import type { ConfigFormType } from '@/components/configForm/formSchema.tsx';
 import {
   FormControl,
   FormDescription,
@@ -11,7 +12,7 @@ import {
 import { Input } from '@/components/ui/input.tsx';
 
 interface Props {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<ConfigFormType>;
 }
 
 export const ServerNameField: FC<Props> = ({ form }) => {

--- a/jellio-web/src/components/configForm/formSchema.tsx
+++ b/jellio-web/src/components/configForm/formSchema.tsx
@@ -15,4 +15,4 @@ export const formSchema = z.object({
   publicBaseUrl: z.string().url().or(z.literal('')).default(''),
 });
 
-export type ConfigFormType = z.infer<typeof formSchema>;
+export type ConfigFormType = z.input<typeof formSchema>;

--- a/jellio-web/src/components/configForm/index.tsx
+++ b/jellio-web/src/components/configForm/index.tsx
@@ -27,6 +27,16 @@ import {
 } from '@/services/backendService';
 import type { ServerInfo } from '@/types';
 
+interface AddonConfiguration {
+  AuthToken: string;
+  LibrariesGuids: string[];
+  ServerName: string;
+  JellyseerrEnabled?: boolean;
+  JellyseerrUrl?: string;
+  JellyseerrApiKey?: string;
+  PublicBaseUrl?: string;
+}
+
 interface Props {
   serverInfo: ServerInfo;
 }
@@ -107,7 +117,7 @@ const ConfigForm: FC<Props> = ({ serverInfo }) => {
     const stripTrailingSlash = (url: string) => url?.replace(/\/+$/, '') || '';
 
     const newToken = await startAddonSession(serverInfo.accessToken);
-    const configuration: any = {
+    const configuration: AddonConfiguration = {
       AuthToken: newToken,
       LibrariesGuids: values.libraries.map((lib) =>
         lib.key.replace(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/, '$1-$2-$3-$4-$5'),
@@ -126,7 +136,7 @@ const ConfigForm: FC<Props> = ({ serverInfo }) => {
     const encodedConfiguration = encode(JSON.stringify(configuration), true);
     const addonUrl = `${getBaseUrl()}/${encodedConfiguration}/manifest.json`;
     if (action === 'clipboard') {
-      navigator.clipboard.writeText(addonUrl);
+      await navigator.clipboard.writeText(addonUrl);
       setCopied(true);
       setTimeout(() => setCopied(false), 1000);
     } else if (action === 'web') {
@@ -154,7 +164,7 @@ const ConfigForm: FC<Props> = ({ serverInfo }) => {
             type="button"
             variant="outline"
             className="w-full max-w-md"
-            onClick={handleSaveToServer}
+            onClick={() => void handleSaveToServer()}
             disabled={saving}
           >
             <Save className="mr-2 h-4 w-4" />

--- a/jellio-web/src/components/logsViewer.tsx
+++ b/jellio-web/src/components/logsViewer.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useState } from 'react';
+import { type FC, useCallback, useEffect, useState } from 'react';
 import { ChevronDown, ChevronUp, RefreshCw, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { getLogs, clearLogs, type LogEntry } from '@/services/backendService';
@@ -13,7 +13,7 @@ export const LogsViewer: FC<LogsViewerProps> = ({ accessToken }) => {
   const [loading, setLoading] = useState(false);
   const [autoRefresh, setAutoRefresh] = useState(false);
 
-  const fetchLogs = async () => {
+  const fetchLogs = useCallback(async () => {
     if (!accessToken) return;
 
     setLoading(true);
@@ -25,7 +25,7 @@ export const LogsViewer: FC<LogsViewerProps> = ({ accessToken }) => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [accessToken]);
 
   const handleClearLogs = async () => {
     if (!accessToken) return;
@@ -40,16 +40,16 @@ export const LogsViewer: FC<LogsViewerProps> = ({ accessToken }) => {
 
   useEffect(() => {
     if (isOpen) {
-      fetchLogs();
+      void fetchLogs();
     }
-  }, [isOpen, accessToken]);
+  }, [isOpen, fetchLogs]);
 
   useEffect(() => {
     if (isOpen && autoRefresh) {
-      const interval = setInterval(fetchLogs, 2000);
+      const interval = setInterval(() => void fetchLogs(), 2000);
       return () => clearInterval(interval);
     }
-  }, [isOpen, autoRefresh, accessToken]);
+  }, [isOpen, autoRefresh, fetchLogs]);
 
   const getLevelColor = (level: string) => {
     switch (level) {
@@ -100,7 +100,7 @@ export const LogsViewer: FC<LogsViewerProps> = ({ accessToken }) => {
               type="button"
               variant="outline"
               size="sm"
-              onClick={fetchLogs}
+              onClick={() => void fetchLogs()}
               disabled={loading}
             >
               <RefreshCw
@@ -112,7 +112,7 @@ export const LogsViewer: FC<LogsViewerProps> = ({ accessToken }) => {
               type="button"
               variant="outline"
               size="sm"
-              onClick={handleClearLogs}
+              onClick={() => void handleClearLogs()}
             >
               <Trash2 className="mr-2 h-4 w-4" />
               Clear

--- a/jellio-web/src/hooks/useAccessToken.ts
+++ b/jellio-web/src/hooks/useAccessToken.ts
@@ -1,37 +1,44 @@
 import { useEffect, useState } from 'react';
+import { z } from 'zod';
 import type { Maybe } from '@/types';
+
+const credentialsSchema = z.object({
+  Servers: z.array(z.object({ AccessToken: z.string().optional() })).optional(),
+  AccessToken: z.string().optional(),
+});
 
 const useAccessToken = (): Maybe<string> => {
   const [accessToken, setAccessToken] = useState<Maybe<string>>();
 
   useEffect(() => {
     try {
-      const storedCredentialsString = localStorage.getItem(
-        'jellyfin_credentials',
-      );
-      if (storedCredentialsString) {
-        const parsed = JSON.parse(storedCredentialsString);
-
-        // Case 1: Web client-style credentials: { Servers: [{ AccessToken }...] }
-        if (parsed?.Servers && Array.isArray(parsed.Servers)) {
-          const withToken = parsed.Servers.find((s: any) => s?.AccessToken);
-          if (withToken?.AccessToken) {
-            setAccessToken(withToken.AccessToken as string);
-            return;
-          }
-        }
-
-        // Case 2: Direct session-style: { AccessToken: "..." }
-        if (
-          typeof parsed?.AccessToken === 'string' &&
-          parsed.AccessToken.length > 0
-        ) {
-          setAccessToken(parsed.AccessToken as string);
-          return;
-        }
+      const stored = localStorage.getItem('jellyfin_credentials');
+      if (!stored) {
+        setAccessToken(null);
+        return;
       }
+
+      const parsed = credentialsSchema.safeParse(JSON.parse(stored));
+      if (!parsed.success) {
+        setAccessToken(null);
+        return;
+      }
+
+      // Case 1: Web client-style credentials: { Servers: [{ AccessToken }...] }
+      const withToken = parsed.data.Servers?.find((s) => s.AccessToken);
+      if (withToken?.AccessToken) {
+        setAccessToken(withToken.AccessToken);
+        return;
+      }
+
+      // Case 2: Direct session-style: { AccessToken: "..." }
+      if (parsed.data.AccessToken) {
+        setAccessToken(parsed.data.AccessToken);
+        return;
+      }
+
       setAccessToken(null);
-    } catch (_err) {
+    } catch {
       setAccessToken(null);
     }
   }, []);

--- a/jellio-web/src/hooks/useConfigStorage.ts
+++ b/jellio-web/src/hooks/useConfigStorage.ts
@@ -1,21 +1,36 @@
 import { useEffect } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
+import { z } from 'zod';
+import type { ConfigFormType } from '@/components/configForm/formSchema';
 import { getConfigFromServer } from '@/services/backendService';
+import type { Library } from '@/types';
 
 const STORAGE_KEY = 'jelliopp_config';
 
-interface StoredConfig {
-  libraries?: { key: string; name: string; type: string }[];
-  jellyseerrEnabled?: boolean;
-  jellyseerrUrl?: string;
-  jellyseerrApiKey?: string;
-  publicBaseUrl?: string;
-}
+const storedConfigSchema = z.object({
+  libraries: z
+    .array(
+      z.object({
+        key: z.string(),
+        name: z.string(),
+        type: z.string(),
+      }),
+    )
+    .optional(),
+  jellyseerrEnabled: z.boolean().optional(),
+  jellyseerrUrl: z.string().optional(),
+  jellyseerrApiKey: z.string().optional(),
+  publicBaseUrl: z.string().optional(),
+});
+
+type StoredConfig = z.infer<typeof storedConfigSchema>;
+
+const stripTrailingSlash = (url: string) => url.replace(/\/+$/, '');
 
 export const useConfigStorage = (
-  form: UseFormReturn<any>,
+  form: UseFormReturn<ConfigFormType>,
   accessToken?: string,
-  availableLibraries?: { key: string; name: string; type: string }[],
+  availableLibraries?: Library[],
 ) => {
   // Load config from localStorage and server on mount
   useEffect(() => {
@@ -24,73 +39,58 @@ export const useConfigStorage = (
         // First try localStorage (faster)
         const stored = localStorage.getItem(STORAGE_KEY);
         if (stored) {
-          const config: StoredConfig = JSON.parse(stored);
-
-          // Update form with stored values
-          if (config.libraries && Array.isArray(config.libraries)) {
-            form.setValue('libraries', config.libraries);
-          }
-          if (config.jellyseerrEnabled !== undefined) {
-            form.setValue('jellyseerrEnabled', config.jellyseerrEnabled);
-          }
-          if (config.jellyseerrUrl) {
-            form.setValue('jellyseerrUrl', config.jellyseerrUrl);
-          }
-          if (config.jellyseerrApiKey) {
-            form.setValue('jellyseerrApiKey', config.jellyseerrApiKey);
-          }
-          if (config.publicBaseUrl) {
-            form.setValue('publicBaseUrl', config.publicBaseUrl);
+          const result = storedConfigSchema.safeParse(JSON.parse(stored));
+          if (result.success) {
+            const config = result.data;
+            if (config.libraries) {
+              form.setValue('libraries', config.libraries);
+            }
+            if (config.jellyseerrEnabled !== undefined) {
+              form.setValue('jellyseerrEnabled', config.jellyseerrEnabled);
+            }
+            if (config.jellyseerrUrl) {
+              form.setValue('jellyseerrUrl', config.jellyseerrUrl);
+            }
+            if (config.jellyseerrApiKey) {
+              form.setValue('jellyseerrApiKey', config.jellyseerrApiKey);
+            }
+            if (config.publicBaseUrl) {
+              form.setValue('publicBaseUrl', config.publicBaseUrl);
+            }
           }
         }
 
         // Then try server config (may override localStorage)
         if (accessToken) {
           const serverConfig = await getConfigFromServer(accessToken);
-          if (serverConfig) {
-            if (serverConfig.jellyseerrEnabled !== undefined) {
-              form.setValue(
-                'jellyseerrEnabled',
-                serverConfig.jellyseerrEnabled,
-              );
-            }
-            if (serverConfig.jellyseerrUrl) {
-              form.setValue('jellyseerrUrl', serverConfig.jellyseerrUrl);
-            }
-            if (serverConfig.jellyseerrApiKey) {
-              form.setValue('jellyseerrApiKey', serverConfig.jellyseerrApiKey);
-            }
-            if (serverConfig.publicBaseUrl) {
-              form.setValue('publicBaseUrl', serverConfig.publicBaseUrl);
-            }
-            // Load libraries from server config if available
-            if (
-              serverConfig.selectedLibraries &&
-              Array.isArray(serverConfig.selectedLibraries) &&
-              availableLibraries
-            ) {
-              // Convert server library IDs (format: "guidwithoutdashes") to form format
-              // Match them with available libraries
-              const selectedLibraries = serverConfig.selectedLibraries
-                .map((id: string) => {
-                  // Convert "guidwithoutdashes" to "guid-with-dashes" format
-                  let formattedId = id;
-                  if (id.length === 32) {
-                    formattedId = `${id.slice(0, 8)}-${id.slice(8, 12)}-${id.slice(12, 16)}-${id.slice(16, 20)}-${id.slice(20, 32)}`;
-                  }
-                  // Find matching library
-                  return availableLibraries.find(
-                    (lib) => lib.key === formattedId,
-                  );
-                })
-                .filter(
-                  (lib): lib is { key: string; name: string; type: string } =>
-                    lib !== undefined,
+          if (serverConfig.jellyseerrEnabled !== undefined) {
+            form.setValue('jellyseerrEnabled', serverConfig.jellyseerrEnabled);
+          }
+          if (serverConfig.jellyseerrUrl) {
+            form.setValue('jellyseerrUrl', serverConfig.jellyseerrUrl);
+          }
+          if (serverConfig.jellyseerrApiKey) {
+            form.setValue('jellyseerrApiKey', serverConfig.jellyseerrApiKey);
+          }
+          if (serverConfig.publicBaseUrl) {
+            form.setValue('publicBaseUrl', serverConfig.publicBaseUrl);
+          }
+          if (serverConfig.selectedLibraries && availableLibraries) {
+            // Server stores library IDs as 32-char guids without dashes
+            const selectedLibraries = serverConfig.selectedLibraries
+              .map((id) => {
+                const formattedId =
+                  id.length === 32
+                    ? `${id.slice(0, 8)}-${id.slice(8, 12)}-${id.slice(12, 16)}-${id.slice(16, 20)}-${id.slice(20, 32)}`
+                    : id;
+                return availableLibraries.find(
+                  (lib) => lib.key === formattedId,
                 );
+              })
+              .filter((lib): lib is Library => lib !== undefined);
 
-              if (selectedLibraries.length > 0) {
-                form.setValue('libraries', selectedLibraries);
-              }
+            if (selectedLibraries.length > 0) {
+              form.setValue('libraries', selectedLibraries);
             }
           }
         }
@@ -99,24 +99,19 @@ export const useConfigStorage = (
       }
     };
 
-    loadConfig();
+    void loadConfig();
   }, [form, accessToken, availableLibraries]);
 
   // Save config to localStorage
   const saveConfig = () => {
     try {
       const values = form.getValues();
-
-      // Strip trailing slashes from URLs before saving
-      const stripTrailingSlash = (url: string) =>
-        url?.replace(/\/+$/, '') || '';
-
       const config: StoredConfig = {
-        libraries: values.libraries || [],
+        libraries: values.libraries,
         jellyseerrEnabled: values.jellyseerrEnabled,
-        jellyseerrUrl: stripTrailingSlash(values.jellyseerrUrl),
+        jellyseerrUrl: stripTrailingSlash(values.jellyseerrUrl ?? ''),
         jellyseerrApiKey: values.jellyseerrApiKey,
-        publicBaseUrl: stripTrailingSlash(values.publicBaseUrl),
+        publicBaseUrl: stripTrailingSlash(values.publicBaseUrl ?? ''),
       };
 
       localStorage.setItem(STORAGE_KEY, JSON.stringify(config));

--- a/jellio-web/src/hooks/useServerInfo.ts
+++ b/jellio-web/src/hooks/useServerInfo.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import axios from 'axios';
 import useAccessToken from '@/hooks/useAccessToken.ts';
 import { getServerInfo } from '@/services/backendService.ts';
 import type { ServerInfo, Maybe } from '@/types';
@@ -16,10 +17,12 @@ const useServerInfo = (): Maybe<ServerInfo> => {
         const info = await getServerInfo(accessToken ?? undefined);
         if (cancelled) return;
         setServerInfo({ accessToken: accessToken ?? '', ...info });
-      } catch (error: any) {
+      } catch (error: unknown) {
         if (cancelled) return;
         // Only treat explicit auth failures as unauthenticated
-        const status = error?.response?.status as number | undefined;
+        const status = axios.isAxiosError(error)
+          ? error.response?.status
+          : undefined;
         if (status === 401 || status === 403) {
           setServerInfo(null);
           return;

--- a/jellio-web/src/services/backendService.ts
+++ b/jellio-web/src/services/backendService.ts
@@ -15,18 +15,21 @@ export const getServerInfo = async (
         `MediaBrowser Client="Jellio++", Device="Web", DeviceId="${deviceId}", Version="1.5.0", Token="${token}"`;
     }
 
-    const response = await axios.get(`${getBaseUrl()}/server-info`, {
+    const response = await axios.get<{
+      name: string;
+      libraries: { Name: string; Id: string; CollectionType: string }[];
+    }>(`${getBaseUrl()}/server-info`, {
       headers,
       withCredentials: true, // Include cookies for Jellyfin session auth
     });
 
     return {
       serverName: response.data.name,
-      libraries: response.data.libraries.map(
-        (lib: { Name: string; Id: string; CollectionType: string }) => {
-          return { name: lib.Name, key: lib.Id, type: lib.CollectionType };
-        },
-      ),
+      libraries: response.data.libraries.map((lib) => ({
+        name: lib.Name,
+        key: lib.Id,
+        type: lib.CollectionType,
+      })),
     };
   } catch (error) {
     console.error('Error while getting server info:', error);
@@ -45,10 +48,14 @@ export const startAddonSession = async (token?: string): Promise<string> => {
         `MediaBrowser Client="Jellio++", Device="Web", DeviceId="${deviceId}", Version="1.5.0", Token="${token}"`;
     }
 
-    const response = await axios.post(`${getBaseUrl()}/start-session`, null, {
-      headers,
-      withCredentials: true,
-    });
+    const response = await axios.post<{ accessToken: string }>(
+      `${getBaseUrl()}/start-session`,
+      null,
+      {
+        headers,
+        withCredentials: true,
+      },
+    );
     return response.data.accessToken;
   } catch (error) {
     console.error('Error starting new session:', error);
@@ -101,10 +108,13 @@ export const getConfigFromServer = async (
         `MediaBrowser Client="Jellio++", Device="Web", DeviceId="${deviceId}", Version="1.5.0", Token="${token}"`;
     }
 
-    const response = await axios.get(`${getBaseUrl()}/get-config`, {
-      headers,
-      withCredentials: true,
-    });
+    const response = await axios.get<SaveConfigData>(
+      `${getBaseUrl()}/get-config`,
+      {
+        headers,
+        withCredentials: true,
+      },
+    );
 
     return response.data;
   } catch (error) {
@@ -134,13 +144,16 @@ export const getLogs = async (
     }
 
     const params = limit ? { limit } : {};
-    const response = await axios.get(`${getBaseUrl()}/logs`, {
-      headers,
-      params,
-      withCredentials: true,
-    });
+    const response = await axios.get<{ logs?: LogEntry[] }>(
+      `${getBaseUrl()}/logs`,
+      {
+        headers,
+        params,
+        withCredentials: true,
+      },
+    );
 
-    return response.data.logs || [];
+    return response.data.logs ?? [];
   } catch (error) {
     console.error('Error getting logs:', error);
     throw error;


### PR DESCRIPTION
- **fix:** `await navigator.clipboard.writeText` - the old code wasn't actually copying anything to the clipboard
- **chore:** replace `any` types across the codebase (axios responses, form types, error catches)
- **refactor:** validate `localStorage` payloads with `zod.safeParse` - improves type-safety