### PR TITLE
Feat/direct play stremio

### DIFF
--- a/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
+++ b/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
@@ -173,8 +173,36 @@ public class AddonController : ControllerBase
                 return Enumerable.Empty<StreamDto>();
             }
 
-            return dto.MediaSources.Select(source =>
+            return dto.MediaSources.SelectMany(source =>
             {
+                var streams = new List<StreamDto>();
+
+                // 1. Direct Play Stream
+                var ext = string.IsNullOrEmpty(source.Container) ? "mp4" : source.Container.Split(',')[0];
+                var dpQuery = QueryString.Create(new Dictionary<string, string?>
+                {
+                    ["static"] = "true",
+                    ["mediaSourceId"] = source.Id,
+                    ["api_key"] = authToken,
+                });
+                var dpStreamUrl = $"{baseUrl}/Videos/{dto.Id}/stream.{ext}{dpQuery}";
+                LogBuffer.AddLog($"[Stream] Generated Direct Play stream for {dto.Name} ({dto.Id}): {source.Name} - URL: {dpStreamUrl}", LogLevel.Info);
+                
+                streams.Add(new StreamDto
+                {
+                    Url = dpStreamUrl,
+                    Name = "Jellio++",
+                    Description = $"Direct Play - {source.Name}",
+                    BehaviorHints = new BehaviorHintsDto
+                    {
+                        Filename = string.IsNullOrEmpty(source.Path) ? null : Path.GetFileName(source.Path),
+                        VideoSize = source.Size,
+                        VideoHash = OpenSubtitlesHash.ComputeFromPath(source.Path),
+                        NotWebReady = true,
+                    },
+                });
+
+                // 2. HLS Stream
                 /*
                  * Jellyfin's HLS endpoint requires the caller to declare which codecs the player supports.
                  * It compares these against the media file's codecs to decide whether to pass through without re-encoding or transcode.
@@ -195,12 +223,13 @@ public class AddonController : ControllerBase
                     ["audioCodec"] = string.Join(',', audioCodecs),
                 });
                 var streamUrl = $"{baseUrl}/Videos/{dto.Id}/master.m3u8{query}";
-                LogBuffer.AddLog($"[Stream] Generated stream for {dto.Name} ({dto.Id}): {source.Name} - URL: {streamUrl}", LogLevel.Info);
-                return new StreamDto
+                LogBuffer.AddLog($"[Stream] Generated HLS stream for {dto.Name} ({dto.Id}): {source.Name} - URL: {streamUrl}", LogLevel.Info);
+                
+                streams.Add(new StreamDto
                 {
                     Url = streamUrl,
                     Name = "Jellio++",
-                    Description = source.Name,
+                    Description = $"HLS - {source.Name}",
                     BehaviorHints = new BehaviorHintsDto
                     {
                         Filename = string.IsNullOrEmpty(source.Path) ? null : Path.GetFileName(source.Path),
@@ -208,7 +237,9 @@ public class AddonController : ControllerBase
                         VideoHash = OpenSubtitlesHash.ComputeFromPath(source.Path),
                         NotWebReady = true,
                     },
-                };
+                });
+
+                return streams;
             });
         }).ToList();
 

--- a/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
+++ b/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
@@ -182,8 +182,9 @@ public class AddonController : ControllerBase
                     ["mediaSourceId"] = source.Id,
                     ["api_key"] = authToken,
                 });
-                var streamUrl = $"{baseUrl}/Videos/{dto.Id}/stream.{ext}{query}";
-                LogBuffer.AddLog($"[Stream] Generated Direct Play stream for {dto.Name} ({dto.Id}): {source.Name} - URL: {streamUrl}", LogLevel.Info);
+var streamUrl = $"{baseUrl}/Videos/{dto.Id}/stream.{ext}{query}";
+var logStreamUrl = $"{baseUrl}/Videos/{dto.Id}/stream.{ext}?static=true&mediaSourceId={source.Id}&api_key=***";
+LogBuffer.AddLog($"[Stream] Generated Direct Play stream for {dto.Name} ({dto.Id}): {source.Name} - URL: {logStreamUrl}", LogLevel.Info);
                 
                 return new StreamDto
                 {

--- a/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
+++ b/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
@@ -173,24 +173,21 @@ public class AddonController : ControllerBase
                 return Enumerable.Empty<StreamDto>();
             }
 
-            return dto.MediaSources.SelectMany(source =>
+            return dto.MediaSources.Select(source =>
             {
-                var streams = new List<StreamDto>();
-
-                // 1. Direct Play Stream
                 var ext = string.IsNullOrEmpty(source.Container) ? "mp4" : source.Container.Split(',')[0];
-                var dpQuery = QueryString.Create(new Dictionary<string, string?>
+                var query = QueryString.Create(new Dictionary<string, string?>
                 {
                     ["static"] = "true",
                     ["mediaSourceId"] = source.Id,
                     ["api_key"] = authToken,
                 });
-                var dpStreamUrl = $"{baseUrl}/Videos/{dto.Id}/stream.{ext}{dpQuery}";
-                LogBuffer.AddLog($"[Stream] Generated Direct Play stream for {dto.Name} ({dto.Id}): {source.Name} - URL: {dpStreamUrl}", LogLevel.Info);
+                var streamUrl = $"{baseUrl}/Videos/{dto.Id}/stream.{ext}{query}";
+                LogBuffer.AddLog($"[Stream] Generated Direct Play stream for {dto.Name} ({dto.Id}): {source.Name} - URL: {streamUrl}", LogLevel.Info);
                 
-                streams.Add(new StreamDto
+                return new StreamDto
                 {
-                    Url = dpStreamUrl,
+                    Url = streamUrl,
                     Name = "Jellio++",
                     Description = $"Direct Play - {source.Name}",
                     BehaviorHints = new BehaviorHintsDto
@@ -200,46 +197,7 @@ public class AddonController : ControllerBase
                         VideoHash = OpenSubtitlesHash.ComputeFromPath(source.Path),
                         NotWebReady = true,
                     },
-                });
-
-                // 2. HLS Stream
-                /*
-                 * Jellyfin's HLS endpoint requires the caller to declare which codecs the player supports.
-                 * It compares these against the media file's codecs to decide whether to pass through without re-encoding or transcode.
-                 *
-                 * Stremio's addon protocol has no mechanism for the client to advertise its codec capabilities to addons, so we hardcode them here. The lists below reflect what Stremio's players can decode. This is the same pattern every Jellyfin client follows - e.g. jellyfin-web builds its codec list.
-                 * See: https://github.com/jellyfin/jellyfin-web/blob/285196329/src/scripts/browserDeviceProfile.js#L914-L925
-                 *
-                 * Without these params Jellyfin would fall back to "m3u8" as the audio codec name, producing invalid FFmpeg commands.
-                 * See: https://github.com/jellyfin/jellyfin/issues/12926
-                 */
-                string[] videoCodecs = ["h264", "hevc", "av1"];
-                string[] audioCodecs = ["aac", "mp3", "ac3", "eac3", "flac", "opus"];
-                var query = QueryString.Create(new Dictionary<string, string?>
-                {
-                    ["mediaSourceId"] = source.Id,
-                    ["api_key"] = authToken,
-                    ["videoCodec"] = string.Join(',', videoCodecs),
-                    ["audioCodec"] = string.Join(',', audioCodecs),
-                });
-                var streamUrl = $"{baseUrl}/Videos/{dto.Id}/master.m3u8{query}";
-                LogBuffer.AddLog($"[Stream] Generated HLS stream for {dto.Name} ({dto.Id}): {source.Name} - URL: {streamUrl}", LogLevel.Info);
-                
-                streams.Add(new StreamDto
-                {
-                    Url = streamUrl,
-                    Name = "Jellio++",
-                    Description = $"HLS - {source.Name}",
-                    BehaviorHints = new BehaviorHintsDto
-                    {
-                        Filename = string.IsNullOrEmpty(source.Path) ? null : Path.GetFileName(source.Path),
-                        VideoSize = source.Size,
-                        VideoHash = OpenSubtitlesHash.ComputeFromPath(source.Path),
-                        NotWebReady = true,
-                    },
-                });
-
-                return streams;
+                };
             });
         }).ToList();
 

--- a/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
+++ b/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
@@ -175,7 +175,24 @@ public class AddonController : ControllerBase
 
             return dto.MediaSources.Select(source =>
             {
-                var ext = string.IsNullOrEmpty(source.Container) ? "mp4" : source.Container.Split(',')[0];
+                var ext = "mp4";
+                if (!string.IsNullOrWhiteSpace(source.Path))
+                {
+                    var pathExt = Path.GetExtension(source.Path);
+                    if (!string.IsNullOrWhiteSpace(pathExt))
+                    {
+                        ext = pathExt.TrimStart('.').ToLowerInvariant();
+                    }
+                }
+                else if (!string.IsNullOrWhiteSpace(source.Container))
+                {
+                    ext = source.Container.Split(',')[0].Trim().ToLowerInvariant();
+                    if (ext == "matroska")
+                    {
+                        ext = "mkv";
+                    }
+                }
+
                 var query = QueryString.Create(new Dictionary<string, string?>
                 {
                     ["static"] = "true",


### PR DESCRIPTION
## Feature: Replace HLS Streaming with Native Direct Play
*(Disclaimer: This feature was developed with AI assistance)*

### Description
This PR changes how Stremio interacts with Jellyfin by replacing the HLS stream generation with pure Direct Play (`?static=true`).

Previously, the plugin forced an HLS stream (`master.m3u8`). This caused Jellyfin to remux or transcode the media into small batched segments in real-time, which created several issues:
1. It constantly writes chunks to the storage device, causing disk thrashing and buffering bottlenecks unless users map a `tmpfs` RAM disk (which is too complex for the average user).  
2. Stremio's player (at least MPV is the only one that worked to even start the stream) couldn't fetch multiple audio tracks and subtitles from the generated HLS manifest. Only the default one.
3. Unreasonable CPU usage due to all the copy operations.

### What Direct Play Fixes
By switching to a Direct Play endpoint (`/stream.ext?static=true`), Jellyfin acts as a standard file server. The client device receives the raw MKV/MP4 file and handles the decoding locally. 
- Full access to all embedded audio and subtitle tracks.
- HDR and Dolby Vision metadata are preserved and successfully display on the TV.
- Low server overhead since Jellyfin no longer has to use FFmpeg

### Testing & Performance

**Host:** Raspberry Pi 4B, 8GB RAM model (Docker)
**Performance:** Tested streaming a 4K 19 Mbps MKV file. Total server CPU usage hovered around 50%, with zero FFmpeg transcoding overhead.

Seamless play, only starting the file took 5 seconds.

**Clients tested:**
- Samsung Galaxy S24 (Android)
- NVIDIA Shield (Android TV) - HDR displays correctly to the TV. 

*Note for Shield/Android TV users:* Depending on the file format, Stremio's default player may struggle with Direct Play. Using a capable external player like a modded MXPlayer is highly recommended for heavy files. 