### PR TITLE
Dodanie zasobu subtitles + direct play / Add Stremio subtitles resource + direct play

### DIFF
--- a/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
+++ b/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
@@ -27,7 +27,7 @@ namespace Jellyfin.Plugin.Jellio.Controllers;
 [ConfigAuthorize]
 [Route("jelliopp/{config}")]
 [Produces(MediaTypeNames.Application.Json)]
-public class AddonController : ControllerBase
+public partial class AddonController : ControllerBase
 {
     private static readonly string PluginVersion =
         Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
@@ -194,7 +194,7 @@ public class AddonController : ControllerBase
                     ["videoCodec"] = string.Join(',', videoCodecs),
                     ["audioCodec"] = string.Join(',', audioCodecs),
                 });
-                var streamUrl = $"{baseUrl}/Videos/{dto.Id}/master.m3u8{query}";
+                var streamUrl = $"{baseUrl}/Videos/{dto.Id}/stream.mp4{query}&static=true";
                 LogBuffer.AddLog($"[Stream] Generated stream for {dto.Name} ({dto.Id}): {source.Name} - URL: {streamUrl}", LogLevel.Info);
                 return new StreamDto
                 {
@@ -206,7 +206,7 @@ public class AddonController : ControllerBase
                         Filename = string.IsNullOrEmpty(source.Path) ? null : Path.GetFileName(source.Path),
                         VideoSize = source.Size,
                         VideoHash = OpenSubtitlesHash.ComputeFromPath(source.Path),
-                        NotWebReady = true,
+                        NotWebReady = false,
                     },
                 };
             });
@@ -260,6 +260,7 @@ public class AddonController : ControllerBase
             {
                 "catalog",
                 "stream",
+                "subtitles",
                 new
                 {
                     name = "meta",

--- a/Jellyfin.Plugin.Jellio/Controllers/AddonControllerSubtitles.cs
+++ b/Jellyfin.Plugin.Jellio/Controllers/AddonControllerSubtitles.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.Jellio.Helpers;
+using Jellyfin.Plugin.Jellio.Models;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Entities;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.Jellio.Controllers;
+
+public partial class AddonController
+{
+    [HttpGet("subtitles/{stremioType}/jelliopp:{mediaId:guid}.json")]
+    [HttpGet("subtitles/{stremioType}/jelliopp:{mediaId:guid}/{extra}.json")]
+    public IActionResult GetSubtitles([ConfigFromBase64Json] ConfigModel config, StremioType stremioType, Guid mediaId, string? extra = null)
+    {
+        var userId = (Guid)HttpContext.Items["JellioUserId"]!;
+        LogBuffer.AddLog($"[Subtitles] req guid={mediaId} extra={extra}", LogLevel.Info);
+        var item = _libraryManager.GetItemById<BaseItem>(mediaId, userId);
+        if (item == null)
+        {
+            return Ok(new { subtitles = Array.Empty<object>() });
+        }
+
+        return BuildSubtitles(userId, [item], config.AuthToken, config.PublicBaseUrl);
+    }
+
+    [HttpGet("subtitles/movie/tt{imdbId}.json")]
+    [HttpGet("subtitles/movie/tt{imdbId}/{extra}.json")]
+    public IActionResult GetSubtitlesImdbMovie([ConfigFromBase64Json] ConfigModel config, string imdbId, string? extra = null)
+    {
+        var userId = (Guid)HttpContext.Items["JellioUserId"]!;
+        LogBuffer.AddLog($"[Subtitles] req imdb=tt{imdbId} extra={extra}", LogLevel.Info);
+        var user = _userManager.GetUserById(userId);
+        if (user == null)
+        {
+            return Unauthorized();
+        }
+
+        var query = new InternalItemsQuery(user)
+        {
+            HasAnyProviderId = new Dictionary<string, string> { ["Imdb"] = $"tt{imdbId}" },
+            IncludeItemTypes = [BaseItemKind.Movie],
+        };
+        return BuildSubtitles(userId, _libraryManager.GetItemList(query), config.AuthToken, config.PublicBaseUrl);
+    }
+
+    private OkObjectResult BuildSubtitles(Guid userId, IReadOnlyList<BaseItem> items, string authToken, string? publicBaseUrl)
+    {
+        var user = _userManager.GetUserById(userId);
+        if (user == null)
+        {
+            return Ok(new { subtitles = Array.Empty<object>() });
+        }
+
+        var baseUrl = GetBaseUrl(publicBaseUrl);
+        var dtos = _dtoService.GetBaseItemDtos(items, new DtoOptions(true), user);
+        var subtitles = new List<SubtitleDto>();
+
+        foreach (var dto in dtos)
+        {
+            if (dto.MediaSources == null)
+            {
+                continue;
+            }
+
+            foreach (var source in dto.MediaSources)
+            {
+                if (source.MediaStreams == null)
+                {
+                    continue;
+                }
+
+                foreach (var ms in source.MediaStreams)
+                {
+                    if (ms.Type != MediaStreamType.Subtitle)
+                    {
+                        continue;
+                    }
+
+                    var lang = string.IsNullOrEmpty(ms.Language) ? "und" : ms.Language;
+                    var url = $"{baseUrl}/Videos/{dto.Id}/{source.Id}/Subtitles/{ms.Index}/0/Stream.srt?api_key={Uri.EscapeDataString(authToken)}";
+                    subtitles.Add(new SubtitleDto { Id = $"jelliopp-{dto.Id}-{ms.Index}", Url = url, Lang = lang });
+                    LogBuffer.AddLog($"[Subtitles] {dto.Name} idx={ms.Index} lang={lang}", LogLevel.Info);
+                }
+            }
+        }
+
+        return Ok(new { subtitles });
+    }
+}

--- a/Jellyfin.Plugin.Jellio/Models/SubtitleDto.cs
+++ b/Jellyfin.Plugin.Jellio/Models/SubtitleDto.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.Jellio.Models;
+
+public class SubtitleDto
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonPropertyName("url")]
+    public required string Url { get; set; }
+
+    [JsonPropertyName("lang")]
+    public required string Lang { get; set; }
+}


### PR DESCRIPTION
## PL

Menu napisów w Stremio nigdy nie pokazywało ścieżek z Jellyfina, ponieważ manifest deklaruje tylko `catalog`, `stream` i `meta`. Ten PR dodaje zasób `subtitles`, który zwraca adresy `Stream.srt` z Jellyfina — dzięki temu napisy osadzone w pliku oraz zewnętrzne pliki .srt pojawiają się w Stremio obok dodatków takich jak napisy24 czy SubSource.

Dodatkowo zmienia adres strumienia na `stream.mp4?...&static=true` (direct play zamiast HLS). Ścieżka HLS uruchamia ffmpeg z `-map -0:s`, co całkowicie usuwa ścieżki napisów. `notWebReady` ustawione na `false`, bo `true` przekazywało odtwarzanie do zewnętrznego odtwarzacza, w którym żaden dodatek nie mógł nałożyć napisów.

Zmiany:
- nowe endpointy `subtitles/{stremioType}/jelliopp:{mediaId}.json` i `subtitles/movie/tt{imdbId}.json` (oba z wariantem `/{extra}.json`, bo Stremio dokleja `videoHash`/`videoSize`)
- nowy model `SubtitleDto` (id / url / lang)
- `AddonController` oznaczony jako `partial`, endpointy w osobnym pliku

## EN

Stremio's subtitle menu never listed Jellyfin's tracks because the manifest declares only `catalog`, `stream` and `meta`. This adds a `subtitles` resource returning Jellyfin `Stream.srt` URLs, so embedded and external subtitles appear alongside addons like napisy24 or SubSource.

It also switches stream URLs to `stream.mp4?...&static=true` (direct play instead of HLS) — the HLS path runs ffmpeg with `-map -0:s`, dropping subtitle streams entirely — and sets `notWebReady` to false, since true pushed playback to an external player where no addon subtitles could be applied.