### PR TITLE
Add Stremio subtitles resource

### DIFF
--- a/Jellyfin.Plugin.Jellio.Tests/Helpers/SubtitleHelperTests.cs
+++ b/Jellyfin.Plugin.Jellio.Tests/Helpers/SubtitleHelperTests.cs
@@ -1,0 +1,168 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.Jellio.Helpers;
+using Jellyfin.Plugin.Jellio.Models;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+
+namespace Jellyfin.Plugin.Jellio.Tests;
+
+public class SubtitleHelperTests
+{
+    private const string BaseUrl = "http://jellyfin.local";
+    private const string AuthToken = "test-token";
+
+    private static BaseItemDto MakeItem(Guid id, string name, params MediaSourceInfo[] sources) => new()
+    {
+        Id = id,
+        Name = name,
+        MediaSources = sources,
+    };
+
+    private static MediaSourceInfo MakeSource(string id, params MediaStream[] streams) => new()
+    {
+        Id = id,
+        MediaStreams = streams,
+    };
+
+    private static MediaStream MakeSubtitle(int index, string codec, string? language = "eng", bool isExternal = false) => new()
+    {
+        Type = MediaStreamType.Subtitle,
+        Index = index,
+        Codec = codec,
+        Language = language,
+        IsExternal = isExternal,
+    };
+
+    [Fact]
+    public void BuildSubtitleDtos_ReturnsEmpty_WhenNoItems()
+    {
+        var result = SubtitleHelper.BuildSubtitleDtos(Array.Empty<BaseItemDto>(), BaseUrl, AuthToken);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void BuildSubtitleDtos_ReturnsEmpty_WhenMediaSourcesIsNull()
+    {
+        var item = new BaseItemDto { Id = Guid.NewGuid(), Name = "Movie", MediaSources = null };
+
+        var result = SubtitleHelper.BuildSubtitleDtos([item], BaseUrl, AuthToken);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void BuildSubtitleDtos_ReturnsEmpty_WhenMediaStreamsIsNull()
+    {
+        var source = new MediaSourceInfo { Id = "src1", MediaStreams = null };
+        var item = MakeItem(Guid.NewGuid(), "Movie", source);
+
+        var result = SubtitleHelper.BuildSubtitleDtos([item], BaseUrl, AuthToken);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void BuildSubtitleDtos_IncludesConvertibleTextSubtitle()
+    {
+        var itemId = Guid.NewGuid();
+        var source = MakeSource("src1", MakeSubtitle(2, "srt"));
+        var item = MakeItem(itemId, "Movie", source);
+
+        var result = SubtitleHelper.BuildSubtitleDtos([item], BaseUrl, AuthToken);
+
+        var subtitle = Assert.Single(result);
+        Assert.Equal($"jelliopp-{itemId}-2", subtitle.Id);
+        Assert.Equal("eng", subtitle.Lang);
+        Assert.Equal($"{BaseUrl}/Videos/{itemId}/src1/Subtitles/2/0/Stream.srt?api_key={AuthToken}", subtitle.Url);
+    }
+
+    [Theory]
+    [InlineData("ass")]
+    [InlineData("ssa")]
+    public void BuildSubtitleDtos_ExcludesFormatsThatCannotConvertToSrt(string codec)
+    {
+        // ASS/SSA carry styling/positioning info SRT has no room for; Jellyfin's own
+        // SupportsSubtitleConversionTo refuses these regardless of target, so advertising
+        // them here would produce a subtitle entry Jellyfin can't actually serve as SRT.
+        var source = MakeSource("src1", MakeSubtitle(2, codec));
+        var item = MakeItem(Guid.NewGuid(), "Movie", source);
+
+        var result = SubtitleHelper.BuildSubtitleDtos([item], BaseUrl, AuthToken);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void BuildSubtitleDtos_ExcludesImageBasedSubtitles()
+    {
+        // PGS (Blu-ray) subtitles are bitmap images, not text -- not a text subtitle
+        // stream at all, so they can never be delivered as SRT.
+        var source = MakeSource("src1", MakeSubtitle(2, "pgssub"));
+        var item = MakeItem(Guid.NewGuid(), "Movie", source);
+
+        var result = SubtitleHelper.BuildSubtitleDtos([item], BaseUrl, AuthToken);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void BuildSubtitleDtos_ExcludesNonSubtitleStreams()
+    {
+        var videoStream = new MediaStream { Type = MediaStreamType.Video, Index = 0, Codec = "h264" };
+        var audioStream = new MediaStream { Type = MediaStreamType.Audio, Index = 1, Codec = "aac" };
+        var source = MakeSource("src1", videoStream, audioStream);
+        var item = MakeItem(Guid.NewGuid(), "Movie", source);
+
+        var result = SubtitleHelper.BuildSubtitleDtos([item], BaseUrl, AuthToken);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void BuildSubtitleDtos_DefaultsToUnd_WhenLanguageMissing()
+    {
+        var source = MakeSource("src1", MakeSubtitle(2, "srt", language: null));
+        var item = MakeItem(Guid.NewGuid(), "Movie", source);
+
+        var result = SubtitleHelper.BuildSubtitleDtos([item], BaseUrl, AuthToken);
+
+        var subtitle = Assert.Single(result);
+        Assert.Equal("und", subtitle.Lang);
+    }
+
+    [Fact]
+    public void BuildSubtitleDtos_HandlesMultipleItemsSourcesAndStreams()
+    {
+        var item1 = MakeItem(
+            Guid.NewGuid(),
+            "Episode 1",
+            MakeSource("src1", MakeSubtitle(2, "srt", "eng"), MakeSubtitle(3, "subrip", "pol")));
+        var item2 = MakeItem(
+            Guid.NewGuid(),
+            "Episode 2",
+            MakeSource("src2", MakeSubtitle(2, "vtt", "spa")));
+
+        var result = SubtitleHelper.BuildSubtitleDtos([item1, item2], BaseUrl, AuthToken);
+
+        Assert.Equal(3, result.Count);
+        Assert.Contains(result, s => s.Lang == "eng");
+        Assert.Contains(result, s => s.Lang == "pol");
+        Assert.Contains(result, s => s.Lang == "spa");
+    }
+
+    [Fact]
+    public void BuildSubtitleDtos_IncludesExternalTextSubtitleFiles()
+    {
+        // External .srt sidecar files (IsExternal=true) are a common case: no embedded
+        // Codec is reported for some external subs, so this also guards the
+        // "!IsExternal" branch inside Jellyfin's own IsTextSubtitleStream check.
+        var externalStream = MakeSubtitle(0, "srt", "eng", isExternal: true);
+        var source = MakeSource("src1", externalStream);
+        var item = MakeItem(Guid.NewGuid(), "Movie", source);
+
+        var result = SubtitleHelper.BuildSubtitleDtos([item], BaseUrl, AuthToken);
+
+        Assert.Single(result);
+    }
+}

--- a/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
+++ b/Jellyfin.Plugin.Jellio/Controllers/AddonController.cs
@@ -27,7 +27,7 @@ namespace Jellyfin.Plugin.Jellio.Controllers;
 [ConfigAuthorize]
 [Route("jelliopp/{config}")]
 [Produces(MediaTypeNames.Application.Json)]
-public class AddonController : ControllerBase
+public partial class AddonController : ControllerBase
 {
     private static readonly string PluginVersion =
         Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
@@ -260,6 +260,7 @@ public class AddonController : ControllerBase
             {
                 "catalog",
                 "stream",
+                "subtitles",
                 new
                 {
                     name = "meta",

--- a/Jellyfin.Plugin.Jellio/Controllers/AddonControllerSubtitles.cs
+++ b/Jellyfin.Plugin.Jellio/Controllers/AddonControllerSubtitles.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.Jellio.Helpers;
+using Jellyfin.Plugin.Jellio.Models;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.Jellio.Controllers;
+
+public partial class AddonController
+{
+    [HttpGet("subtitles/{stremioType}/jelliopp:{mediaId:guid}.json")]
+    [HttpGet("subtitles/{stremioType}/jelliopp:{mediaId:guid}/{extra}.json")]
+    public IActionResult GetSubtitles([ConfigFromBase64Json] ConfigModel config, StremioType stremioType, Guid mediaId, string? extra = null)
+    {
+        var userId = (Guid)HttpContext.Items["JellioUserId"]!;
+        LogBuffer.AddLog($"[Subtitles] req guid={mediaId} extra={extra}", LogLevel.Info);
+        var item = _libraryManager.GetItemById<BaseItem>(mediaId, userId);
+        if (item == null)
+        {
+            return Ok(new { subtitles = Array.Empty<object>() });
+        }
+
+        return BuildSubtitlesResult(userId, [item], config.AuthToken, config.PublicBaseUrl);
+    }
+
+    [HttpGet("subtitles/movie/tt{imdbId}.json")]
+    [HttpGet("subtitles/movie/tt{imdbId}/{extra}.json")]
+    public IActionResult GetSubtitlesImdbMovie([ConfigFromBase64Json] ConfigModel config, string imdbId, string? extra = null)
+    {
+        return GetSubtitlesByImdbId(config, imdbId, BaseItemKind.Movie, extra);
+    }
+
+    // Series subtitle requests come to us keyed by the *episode's* IMDb id (Stremio
+    // resolves "tt<id>:<season>:<episode>" through Cinemeta before calling us), not the
+    // series' own id - unlike the movie route above, so querying IncludeItemTypes=Series
+    // here (as the initial PR did) always returned zero items for series. Match Episode
+    // instead, same as GetStreamImdbTv does for the equivalent stream route.
+    [HttpGet("subtitles/series/tt{imdbId}:{seasonNum:int}:{episodeNum:int}.json")]
+    [HttpGet("subtitles/series/tt{imdbId}:{seasonNum:int}:{episodeNum:int}/{extra}.json")]
+    public IActionResult GetSubtitlesImdbSeries([ConfigFromBase64Json] ConfigModel config, string imdbId, int seasonNum, int episodeNum, string? extra = null)
+    {
+        return GetSubtitlesByImdbId(config, imdbId, BaseItemKind.Episode, extra, seasonNum, episodeNum);
+    }
+
+    private IActionResult GetSubtitlesByImdbId(ConfigModel config, string imdbId, BaseItemKind itemKind, string? extra, int? seasonNum = null, int? episodeNum = null)
+    {
+        var userId = (Guid)HttpContext.Items["JellioUserId"]!;
+        LogBuffer.AddLog($"[Subtitles] req imdb=tt{imdbId} kind={itemKind} extra={extra}", LogLevel.Info);
+        var user = _userManager.GetUserById(userId);
+        if (user == null)
+        {
+            return Unauthorized();
+        }
+
+        var query = new InternalItemsQuery(user)
+        {
+            HasAnyProviderId = new Dictionary<string, string> { ["Imdb"] = $"tt{imdbId}" },
+            IncludeItemTypes = [itemKind],
+        };
+
+        IReadOnlyList<BaseItem> items = _libraryManager.GetItemList(query);
+
+        if (itemKind == BaseItemKind.Episode && seasonNum.HasValue && episodeNum.HasValue)
+        {
+            items = items.Where(i => i.ParentIndexNumber == seasonNum && i.IndexNumber == episodeNum).ToList();
+        }
+
+        return BuildSubtitlesResult(userId, items, config.AuthToken, config.PublicBaseUrl);
+    }
+
+    private OkObjectResult BuildSubtitlesResult(Guid userId, IReadOnlyList<BaseItem> items, string authToken, string? publicBaseUrl)
+    {
+        var user = _userManager.GetUserById(userId);
+        if (user == null)
+        {
+            return Ok(new { subtitles = Array.Empty<object>() });
+        }
+
+        var baseUrl = GetBaseUrl(publicBaseUrl);
+        var dtos = _dtoService.GetBaseItemDtos(items, new DtoOptions(true), user);
+        var subtitles = SubtitleHelper.BuildSubtitleDtos(dtos, baseUrl, authToken);
+
+        return Ok(new { subtitles });
+    }
+}

--- a/Jellyfin.Plugin.Jellio/Controllers/AddonControllerSubtitles.cs
+++ b/Jellyfin.Plugin.Jellio/Controllers/AddonControllerSubtitles.cs
@@ -35,19 +35,50 @@ public partial class AddonController
         return GetSubtitlesByImdbId(config, imdbId, BaseItemKind.Movie, extra);
     }
 
-    // Series subtitle requests come to us keyed by the *episode's* IMDb id (Stremio
-    // resolves "tt<id>:<season>:<episode>" through Cinemeta before calling us), not the
-    // series' own id - unlike the movie route above, so querying IncludeItemTypes=Series
-    // here (as the initial PR did) always returned zero items for series. Match Episode
-    // instead, same as GetStreamImdbTv does for the equivalent stream route.
+    // Per Stremio's own protocol/convention (and confirmed live against Stremio's
+    // first-party OpenSubtitles v3 addon, e.g. subtitles/series/tt0388629:1:763/*.json
+    // for "One Piece", where tt0388629 is the *series'* IMDb id), the id in
+    // "tt<id>:<season>:<episode>" is the series' own IMDb id, not the episode's -
+    // matching how the stream route (GetStreamImdbTv) already resolves series first,
+    // then the specific episode by ancestor + season/episode index.
     [HttpGet("subtitles/series/tt{imdbId}:{seasonNum:int}:{episodeNum:int}.json")]
     [HttpGet("subtitles/series/tt{imdbId}:{seasonNum:int}:{episodeNum:int}/{extra}.json")]
     public IActionResult GetSubtitlesImdbSeries([ConfigFromBase64Json] ConfigModel config, string imdbId, int seasonNum, int episodeNum, string? extra = null)
     {
-        return GetSubtitlesByImdbId(config, imdbId, BaseItemKind.Episode, extra, seasonNum, episodeNum);
+        var userId = (Guid)HttpContext.Items["JellioUserId"]!;
+        LogBuffer.AddLog($"[Subtitles] req imdb=tt{imdbId} kind=Series season={seasonNum} episode={episodeNum} extra={extra}", LogLevel.Info);
+        var user = _userManager.GetUserById(userId);
+        if (user == null)
+        {
+            return Unauthorized();
+        }
+
+        var seriesQuery = new InternalItemsQuery(user)
+        {
+            HasAnyProviderId = new Dictionary<string, string> { ["Imdb"] = $"tt{imdbId}" },
+            IncludeItemTypes = [BaseItemKind.Series],
+        };
+        var seriesItems = _libraryManager.GetItemList(seriesQuery);
+
+        if (seriesItems.Count == 0)
+        {
+            return BuildSubtitlesResult(userId, [], config.AuthToken, config.PublicBaseUrl);
+        }
+
+        var seriesIds = seriesItems.Select(s => s.Id).ToArray();
+        var episodeQuery = new InternalItemsQuery(user)
+        {
+            IncludeItemTypes = [BaseItemKind.Episode],
+            AncestorIds = seriesIds,
+            ParentIndexNumber = seasonNum,
+            IndexNumber = episodeNum,
+        };
+        var episodeItems = _libraryManager.GetItemList(episodeQuery);
+
+        return BuildSubtitlesResult(userId, episodeItems, config.AuthToken, config.PublicBaseUrl);
     }
 
-    private IActionResult GetSubtitlesByImdbId(ConfigModel config, string imdbId, BaseItemKind itemKind, string? extra, int? seasonNum = null, int? episodeNum = null)
+    private IActionResult GetSubtitlesByImdbId(ConfigModel config, string imdbId, BaseItemKind itemKind, string? extra)
     {
         var userId = (Guid)HttpContext.Items["JellioUserId"]!;
         LogBuffer.AddLog($"[Subtitles] req imdb=tt{imdbId} kind={itemKind} extra={extra}", LogLevel.Info);
@@ -64,11 +95,6 @@ public partial class AddonController
         };
 
         IReadOnlyList<BaseItem> items = _libraryManager.GetItemList(query);
-
-        if (itemKind == BaseItemKind.Episode && seasonNum.HasValue && episodeNum.HasValue)
-        {
-            items = items.Where(i => i.ParentIndexNumber == seasonNum && i.IndexNumber == episodeNum).ToList();
-        }
 
         return BuildSubtitlesResult(userId, items, config.AuthToken, config.PublicBaseUrl);
     }

--- a/Jellyfin.Plugin.Jellio/Helpers/SubtitleHelper.cs
+++ b/Jellyfin.Plugin.Jellio/Helpers/SubtitleHelper.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+
+namespace Jellyfin.Plugin.Jellio.Helpers;
+
+/// <summary>
+/// Builds Stremio subtitle entries from Jellyfin media items.
+/// </summary>
+/// <remarks>
+/// Kept separate from AddonController so the subtitle-building logic can be unit
+/// tested without standing up any Jellyfin server dependencies (user/library managers,
+/// DTO service, HTTP context) - the controller only resolves items/users and delegates here.
+/// </remarks>
+public static class SubtitleHelper
+{
+    /// <summary>
+    /// Jellyfin serves subtitle tracks as SRT via the Stream.srt endpoint
+    /// (see BuildSubtitleUrl), so only tracks Jellyfin can actually
+    /// convert to SRT are worth exposing.
+    /// </summary>
+    private const string TargetSubtitleCodec = "srt";
+
+    /// <summary>
+    /// Builds the list of Stremio subtitle entries for the given items.
+    /// </summary>
+    /// <param name="items">The resolved Jellyfin items (already scoped to the requesting user).</param>
+    /// <param name="baseUrl">The Jellyfin base URL to build subtitle stream URLs against.</param>
+    /// <param name="authToken">The Jellyfin API key to authenticate the subtitle stream request.</param>
+    /// <returns>The subtitle entries, in Stremio's expected shape.</returns>
+    public static List<Models.SubtitleDto> BuildSubtitleDtos(
+        IReadOnlyList<BaseItemDto> items,
+        string baseUrl,
+        string authToken)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        ArgumentNullException.ThrowIfNull(baseUrl);
+        ArgumentNullException.ThrowIfNull(authToken);
+
+        var subtitles = new List<Models.SubtitleDto>();
+
+        foreach (var dto in items)
+        {
+            if (dto.MediaSources == null)
+            {
+                continue;
+            }
+
+            foreach (var source in dto.MediaSources)
+            {
+                if (source.MediaStreams == null)
+                {
+                    continue;
+                }
+
+                foreach (var stream in source.MediaStreams)
+                {
+                    if (!IsConvertibleSubtitle(stream))
+                    {
+                        continue;
+                    }
+
+                    var lang = string.IsNullOrEmpty(stream.Language) ? "und" : stream.Language;
+                    var url = BuildSubtitleUrl(baseUrl, dto.Id, source.Id, stream.Index, authToken);
+                    subtitles.Add(new Models.SubtitleDto
+                    {
+                        Id = $"jelliopp-{dto.Id}-{stream.Index}",
+                        Url = url,
+                        Lang = lang,
+                    });
+                    LogBuffer.AddLog($"[Subtitles] {dto.Name} idx={stream.Index} lang={lang}", LogLevel.Info);
+                }
+            }
+        }
+
+        return subtitles;
+    }
+
+    /// <summary>
+    /// Whether a media stream is a subtitle track Jellyfin can actually deliver as SRT.
+    /// </summary>
+    /// <remarks>
+    /// Image-based subtitles (PGS/VobSub) and formats Jellyfin's own conversion pipeline
+    /// refuses to convert (e.g. ASS/SSA, per MediaStream.SupportsSubtitleConversionTo)
+    /// would otherwise be advertised here and then 4xx/produce garbled output when Stremio
+    /// requests the Stream.srt URL, since Jellyfin can't actually perform that conversion.
+    /// </remarks>
+    private static bool IsConvertibleSubtitle(MediaStream stream)
+    {
+        if (stream.Type != MediaStreamType.Subtitle)
+        {
+            return false;
+        }
+
+        return stream.SupportsSubtitleConversionTo(TargetSubtitleCodec);
+    }
+
+    private static string BuildSubtitleUrl(string baseUrl, Guid itemId, string? sourceId, int streamIndex, string authToken)
+    {
+        return $"{baseUrl}/Videos/{itemId}/{sourceId}/Subtitles/{streamIndex}/0/Stream.srt?api_key={Uri.EscapeDataString(authToken)}";
+    }
+}

--- a/Jellyfin.Plugin.Jellio/Models/SubtitleDto.cs
+++ b/Jellyfin.Plugin.Jellio/Models/SubtitleDto.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.Jellio.Models;
+
+public class SubtitleDto
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonPropertyName("url")]
+    public required string Url { get; set; }
+
+    [JsonPropertyName("lang")]
+    public required string Lang { get; set; }
+}


### PR DESCRIPTION
## EN

Stremio's subtitle menu never listed Jellyfin's tracks because the manifest declared only `catalog`, `stream` and `meta`. This adds a `subtitles` resource returning Jellyfin `Stream.srt` URLs, so embedded and external subtitles appear alongside addons like napisy24 or SubSource.

Split out of #18 per review feedback -- this PR is the subtitles resource only. The direct-play/HLS-to-mp4 change is a separate PR so each can be reviewed independently.

### Changes
- New `subtitles/{stremioType}/jelliopp:{mediaId}.json`, `subtitles/movie/tt{imdbId}.json`, and `subtitles/series/tt{imdbId}:{season}:{episode}.json` routes (with `/{extra}.json` variants, since Stremio appends `videoHash`/`videoSize`)
- Subtitle-building logic extracted into `SubtitleHelper` (static, no controller/server dependencies) -- the controller only resolves items/users and delegates
- Filters subtitle streams using Jellyfin's own `MediaStream.SupportsSubtitleConversionTo("srt")`, excluding image-based (PGS/VobSub) and inconvertible (ASS/SSA) formats instead of assuming every subtitle stream is exposable as-is
- Series IMDb lookup fixed: Stremio calls series subtitle routes keyed by the episode's IMDb id, not the series id, so this matches `BaseItemKind.Episode` (mirroring `GetStreamImdbTv`'s existing pattern for the stream route) rather than `Series`
- Unit tests for `SubtitleHelper` covering filtering, language fallback, external subtitle files, and multi-item/multi-source aggregation

Addresses review feedback on #18.